### PR TITLE
feat(oauth): allow explicit scope for sasl_azure_entra

### DIFF
--- a/pkg/kafka/auth.go
+++ b/pkg/kafka/auth.go
@@ -25,6 +25,12 @@ type SASLConfig struct {
 	Password   string `json:"password"`
 	Algorithm  string `json:"algorithm"`
 	AWSProfile string `json:"awsProfile"`
+	// Scope overrides the auto-derived OAuth scope for sasl_azure_entra.
+	// Required when the broker hostname is not a valid Entra resource
+	// (e.g. self-hosted Kafka with Entra ID via app registration). When
+	// empty, scope defaults to "https://<broker-host>/.default" — the
+	// Event Hubs convention.
+	Scope string `json:"scope"`
 }
 
 type SASLContext struct {
@@ -40,7 +46,11 @@ func NewSaslContext(saslConfig SASLConfig, brokers []string, opts SASLContextOpt
 
 	switch saslConfig.Algorithm {
 	case saslAzureEntra:
-		oauthProvider, err := NewOAuthProvider(saslConfig.Algorithm, brokers, opts.OAuthProviderOpts)
+		providerOpts := opts.OAuthProviderOpts
+		if providerOpts.scope == "" {
+			providerOpts.scope = saslConfig.Scope
+		}
+		oauthProvider, err := NewOAuthProvider(saslConfig.Algorithm, brokers, providerOpts)
 		if err != nil {
 			return SASLContext{}, err
 		}

--- a/pkg/kafka/oauth.go
+++ b/pkg/kafka/oauth.go
@@ -26,6 +26,7 @@ type OAuthTokenProvider interface {
 
 type OAuthProviderOpts struct {
 	azureTokenCredential azcore.TokenCredential
+	scope                string
 }
 
 type OAuthTokenHandler interface {
@@ -35,7 +36,7 @@ type OAuthTokenHandler interface {
 
 func NewOAuthProvider(saslAlgorithm string, brokers []string, opts OAuthProviderOpts) (OAuthTokenProvider, error) {
 	if saslAlgorithm == saslAzureEntra {
-		return newAzureEntraOAuthTokenProvider(brokers, opts.azureTokenCredential)
+		return newAzureEntraOAuthTokenProvider(brokers, opts.azureTokenCredential, opts.scope)
 	}
 
 	return nil, NewXk6KafkaError(failedCreateOAuthTokenProvider, saslAlgorithm+" is not a supported OAuth Provider.", nil)
@@ -47,7 +48,7 @@ type AzureEntraOAuthTokenProvider struct {
 }
 
 func newAzureEntraOAuthTokenProvider(
-	brokers []string, tokenCredential azcore.TokenCredential,
+	brokers []string, tokenCredential azcore.TokenCredential, scopeOverride string,
 ) (*AzureEntraOAuthTokenProvider, error) {
 	var cred azcore.TokenCredential
 	var err error
@@ -65,7 +66,10 @@ func newAzureEntraOAuthTokenProvider(
 		return nil, NewXk6KafkaError(failedGetOAuthToken, "Azure Entra OAuth requires a valid host:port for the broker.", err)
 	}
 
-	scope := fmt.Sprintf("https://%s/.default", host)
+	scope := scopeOverride
+	if scope == "" {
+		scope = fmt.Sprintf("https://%s/.default", host)
+	}
 
 	if tokenCredential == nil {
 		cred, err = azidentity.NewDefaultAzureCredential(nil)

--- a/pkg/kafka/oauth_test.go
+++ b/pkg/kafka/oauth_test.go
@@ -18,14 +18,19 @@ var (
 )
 
 type testTokenCredential struct {
-	Subject string
-	Error   error
+	Subject       string
+	Error         error
+	LastScopes    []string
+	LastEnableCAE bool
 }
 
 func (t *testTokenCredential) GetToken(
 	ctx context.Context,
 	opts policy.TokenRequestOptions,
 ) (azcore.AccessToken, error) {
+	t.LastScopes = opts.Scopes
+	t.LastEnableCAE = opts.EnableCAE
+
 	if t.Error != nil {
 		return azcore.AccessToken{}, t.Error
 	}
@@ -113,4 +118,49 @@ func TestGetOAuthTokenFailure(t *testing.T) {
 func TestUnsupportedOAuthProvider(t *testing.T) {
 	_, err := NewOAuthProvider(saslPlain, []string{"broker1"}, OAuthProviderOpts{})
 	require.ErrorContains(t, err, "sasl_plain is not a supported OAuth Provider.")
+}
+
+// TestAzureEntraScopeOverride verifies that the SASLConfig.Scope field
+// overrides the auto-derived "https://<broker-host>/.default" scope.
+// Self-hosted Kafka brokers using Entra ID via an app registration need
+// the override; Event Hubs deployments still rely on auto-derivation.
+func TestAzureEntraScopeOverride(t *testing.T) {
+	const overrideScope = "api://00000000-0000-0000-0000-000000000000/.default"
+
+	testCases := map[string]struct {
+		saslConfig     SASLConfig
+		brokers        []string
+		expectedScopes []string
+	}{
+		"explicit scope overrides auto-derivation": {
+			saslConfig: SASLConfig{
+				Algorithm: saslAzureEntra,
+				Scope:     overrideScope,
+			},
+			brokers:        []string{"broker.example.invalid:9093"},
+			expectedScopes: []string{overrideScope},
+		},
+		"empty scope falls back to host-derived default": {
+			saslConfig: SASLConfig{
+				Algorithm: saslAzureEntra,
+			},
+			brokers:        []string{"ns.servicebus.windows.net:9093"},
+			expectedScopes: []string{"https://ns.servicebus.windows.net/.default"},
+		},
+	}
+
+	for name, test := range testCases {
+		t.Run(name, func(t *testing.T) {
+			cred := &testTokenCredential{Subject: "test-sub"}
+			ctx, err := NewSaslContext(test.saslConfig, test.brokers, SASLContextOpts{
+				OAuthProviderOpts: OAuthProviderOpts{azureTokenCredential: cred},
+			})
+			require.NoError(t, err)
+			require.NotNil(t, ctx.OAuthProvider, "OAuthProvider should be set for sasl_azure_entra")
+
+			_, err = (*ctx.OAuthProvider).GetToken(t.Context())
+			require.NoError(t, err)
+			require.Equal(t, test.expectedScopes, cred.LastScopes)
+		})
+	}
 }


### PR DESCRIPTION
## Summary

- Adds a `scope` field to `SASLConfig` that overrides the auto-derived OAuth scope when using `sasl_azure_entra`.
- Preserves the existing Event Hubs default (`https://<broker-host>/.default`) when `scope` is empty.

## Motivation

The Azure Entra OAuth provider in [pkg/kafka/oauth.go](pkg/kafka/oauth.go) derives the token scope from the broker hostname:

```go
scope := fmt.Sprintf("https://%s/.default", host)
```

This works for Azure Event Hubs (where the broker hostname *is* the resource), but breaks for self-hosted Kafka brokers authenticating via Entra ID through an app registration. In that case the scope is unrelated to the broker hostname (typically `api://<app-id>/.default`), and Entra rejects the token request with:

```
AADSTS500011: The resource principal named https://<broker-host> was not found in the tenant.
```

## Change

```go
type SASLConfig struct {
    ...
    Scope string `json:"scope"`
}
```

When set, the value flows through `OAuthProviderOpts.scope` into `newAzureEntraOAuthTokenProvider` and replaces the auto-derived value.

## JS usage

```js
const saslConfig = {
  algorithm: SASL_AZURE_ENTRA,
  scope: "api://<your-app-id>/.default",
};
```

Existing Event Hubs scripts that don't set `scope` keep working unchanged.

## Test plan

- [ ] Local: `go build ./pkg/kafka/...` — clean
- [ ] Local: `go vet ./pkg/kafka/...` — clean
- [ ] CI: build workflow passes on all platforms
- [ ] Smoke: run a k6 script against a self-hosted Kafka broker with Entra ID auth and verify a token is acquired (no AADSTS500011)
- [ ] Regression: run `scripts/test_azure_event_hub.js` (no `scope` set) — token request should still go to `https://<namespace>.servicebus.windows.net/.default`