### PR TITLE
feat(config): raw librdkafka config passthrough for writer/reader/connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,7 +528,7 @@ For v2.0.0+ examples using the new constructors (`Producer`, `Consumer`, `AdminC
 ### FAQ
 
 <details>
-<summary>Click to expand FAQ (17 questions)</summary>
+<summary>Click to expand FAQ (16 questions)</summary>
 
 1. Why do I receive `Error writing messages`?
 
@@ -699,30 +699,6 @@ For v2.0.0+ examples using the new constructors (`Producer`, `Consumer`, `AdminC
 16. What if I want to use a custom profile for the SASL authentication with AWS IAM instead of the default profile?
 
     You can use the `AWS_PROFILE` environment variable to specify the profile name or use the `awsProfile` option in the `SASLConfig` [object](api-docs/v2/docs/interfaces/SASLConfig.md).
-
-17. Why does memory usage explode when I start many VUs, and why doesn't `GOMEMLIMIT` help?
-
-    Each VU that constructs a `Writer`/`Reader` gets its own [librdkafka](https://github.com/confluentinc/librdkafka) client (via `confluent-kafka-go`), and VUs cannot share one. That client allocates its buffers and threads as **native (C) memory**, which is invisible to the Go garbage collector — so `GOMEMLIMIT`, which only bounds the Go heap, has no effect on it.
-
-    The dominant cost is the producer send queue, capped by `queue.buffering.max.kbytes` at **1 GiB per client** by default; consumers buffer up to `queued.max.messages.kbytes` (64 MiB) **per partition**. With many VUs these ceilings add up fast.
-
-    To keep memory bounded:
-
-    - **Use fewer clients.** Create the `Writer`/`Reader` once in the `init` context (not per iteration), run fewer VUs at higher throughput, and `produce()` in batches.
-    - **Cap the buffers** with the raw config passthrough — `producerConfig` on `WriterConfig` and `consumerConfig` on `ReaderConfig` (see the [writer](docs/writers.md) and [reader](docs/readers.md) docs):
-
-      ```javascript
-      const writer = new Writer({
-        brokers: ["localhost:9092"],
-        topic: "my-topic",
-        producerConfig: {
-          "queue.buffering.max.kbytes": 65536, // 64 MiB per client instead of 1 GiB
-        },
-      });
-      ```
-
-      Security and connection keys (`bootstrap.servers`, `security.protocol`, `ssl.*`, `sasl.*`, `enable.ssl.certificate.verification`) and any property already managed by the typed config fields cannot be overridden through these maps and are ignored with a warning.
-    - **Enforce a hard ceiling at the OS level** (e.g. a container `--memory` limit). Combined with bounded buffers, steady-state stays under the limit.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -528,7 +528,7 @@ For v2.0.0+ examples using the new constructors (`Producer`, `Consumer`, `AdminC
 ### FAQ
 
 <details>
-<summary>Click to expand FAQ (16 questions)</summary>
+<summary>Click to expand FAQ (17 questions)</summary>
 
 1. Why do I receive `Error writing messages`?
 
@@ -699,6 +699,30 @@ For v2.0.0+ examples using the new constructors (`Producer`, `Consumer`, `AdminC
 16. What if I want to use a custom profile for the SASL authentication with AWS IAM instead of the default profile?
 
     You can use the `AWS_PROFILE` environment variable to specify the profile name or use the `awsProfile` option in the `SASLConfig` [object](api-docs/v2/docs/interfaces/SASLConfig.md).
+
+17. Why does memory usage explode when I start many VUs, and why doesn't `GOMEMLIMIT` help?
+
+    Each VU that constructs a `Writer`/`Reader` gets its own [librdkafka](https://github.com/confluentinc/librdkafka) client (via `confluent-kafka-go`), and VUs cannot share one. That client allocates its buffers and threads as **native (C) memory**, which is invisible to the Go garbage collector — so `GOMEMLIMIT`, which only bounds the Go heap, has no effect on it.
+
+    The dominant cost is the producer send queue, capped by `queue.buffering.max.kbytes` at **1 GiB per client** by default; consumers buffer up to `queued.max.messages.kbytes` (64 MiB) **per partition**. With many VUs these ceilings add up fast.
+
+    To keep memory bounded:
+
+    - **Use fewer clients.** Create the `Writer`/`Reader` once in the `init` context (not per iteration), run fewer VUs at higher throughput, and `produce()` in batches.
+    - **Cap the buffers** with the raw config passthrough — `producerConfig` on `WriterConfig` and `consumerConfig` on `ReaderConfig` (see the [writer](docs/writers.md) and [reader](docs/readers.md) docs):
+
+      ```javascript
+      const writer = new Writer({
+        brokers: ["localhost:9092"],
+        topic: "my-topic",
+        producerConfig: {
+          "queue.buffering.max.kbytes": 65536, // 64 MiB per client instead of 1 GiB
+        },
+      });
+      ```
+
+      Security and connection keys (`bootstrap.servers`, `security.protocol`, `ssl.*`, `sasl.*`, `enable.ssl.certificate.verification`) and any property already managed by the typed config fields cannot be overridden through these maps and are ignored with a warning.
+    - **Enforce a hard ceiling at the OS level** (e.g. a container `--memory` limit). Combined with bounded buffers, steady-state stays under the limit.
 
 </details>
 

--- a/docs/readers.md
+++ b/docs/readers.md
@@ -68,7 +68,7 @@ All the parameters are named following the camelCase notation style.
 
 ### Tuning the underlying client with `consumerConfig`
 
-The reader is backed by [librdkafka](https://github.com/confluentinc/librdkafka) (via `confluent-kafka-go`). `consumerConfig` is an escape hatch that passes any [librdkafka consumer property](https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md) straight to the client — useful for **bounding per-client memory**, since each reader is its own librdkafka instance and the fetch buffers (`queued.max.messages.kbytes`, default 64 MiB **per partition**) accumulate across many VUs.
+The reader is backed by [librdkafka](https://github.com/confluentinc/librdkafka) (via `confluent-kafka-go`). `consumerConfig` is an escape hatch that passes any [librdkafka consumer property](https://docs.confluent.io/platform/current/clients/librdkafka/html/md_CONFIGURATION.html) straight to the client (see that page for the full list of available settings) — useful for **bounding per-client memory**, since each reader is its own librdkafka instance and the fetch buffers (`queued.max.messages.kbytes`, default 64 MiB **per partition**) accumulate across many VUs.
 
 ```javascript
 const consumer = new Reader({

--- a/docs/readers.md
+++ b/docs/readers.md
@@ -57,13 +57,32 @@ type ReaderConfig struct {
 	RetentionTime          time.Duration `json:"retentionTime"`
 	ReadBackoffMin         time.Duration `json:"readBackoffMin"`
 	ReadBackoffMax         time.Duration `json:"readBackoffMax"`
-	OffsetOutOfRangeError  bool          `json:"offsetOutOfRangeError"` // deprecated, do not use
-	SASL                   SASLConfig    `json:"sasl"`
-	TLS                    TLSConfig     `json:"tls"`
+	OffsetOutOfRangeError  bool           `json:"offsetOutOfRangeError"` // deprecated, do not use
+	SASL                   SASLConfig     `json:"sasl"`
+	TLS                    TLSConfig      `json:"tls"`
+	ConsumerConfig         map[string]any `json:"consumerConfig"`
 }
 ```
 
 All the parameters are named following the camelCase notation style.
+
+### Tuning the underlying client with `consumerConfig`
+
+The reader is backed by [librdkafka](https://github.com/confluentinc/librdkafka) (via `confluent-kafka-go`). `consumerConfig` is an escape hatch that passes any [librdkafka consumer property](https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md) straight to the client — useful for **bounding per-client memory**, since each reader is its own librdkafka instance and the fetch buffers (`queued.max.messages.kbytes`, default 64 MiB **per partition**) accumulate across many VUs.
+
+```javascript
+const consumer = new Reader({
+  brokers,
+  groupId,
+  topic,
+  consumerConfig: {
+    "queued.max.messages.kbytes": 4096, // cap the fetch buffer at 4 MiB per partition (default 64 MiB)
+    "fetch.message.max.bytes": 1048576,
+  },
+});
+```
+
+**Protected keys.** To avoid weakening the connection, `consumerConfig` cannot set or override security/connection keys (`bootstrap.servers`, `security.protocol`, `ssl.*`, `sasl.*`, `enable.ssl.certificate.verification` — configure these via `brokers`, `sasl`, and `tls`), nor any property already managed by the typed fields above. Such keys are ignored with a warning in the logs.
 
 ---
 

--- a/docs/writers.md
+++ b/docs/writers.md
@@ -41,13 +41,40 @@ type WriterConfig struct {
 	Brokers         []string      `json:"brokers"`
 	BatchTimeout    time.Duration `json:"batchTimeout"`
 	ReadTimeout     time.Duration `json:"readTimeout"`
-	WriteTimeout    time.Duration `json:"writeTimeout"`
-	SASL            SASLConfig    `json:"sasl"`
-	TLS             TLSConfig     `json:"tls"`
+	WriteTimeout    time.Duration  `json:"writeTimeout"`
+	SASL            SASLConfig     `json:"sasl"`
+	TLS             TLSConfig      `json:"tls"`
+	ProducerConfig  map[string]any `json:"producerConfig"`
 }
 ```
 
 All the parameters are named following the camelCase notation style.
+
+### Tuning the underlying client with `producerConfig`
+
+The writer is backed by [librdkafka](https://github.com/confluentinc/librdkafka) (via `confluent-kafka-go`). The typed fields above only map a handful of properties; `producerConfig` is an escape hatch that passes any [librdkafka producer property](https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md) straight to the client.
+
+This is the main lever for **bounding per-client memory**. Each writer is its own librdkafka instance, and the default send-queue ceiling (`queue.buffering.max.kbytes`) is **1 GiB per client** — so many VUs can reserve a lot of headroom. Lower it to cap memory:
+
+```javascript
+const producer = new Writer({
+  brokers,
+  topic: topicName,
+  compression: CODEC_LZ4,
+  producerConfig: {
+    "queue.buffering.max.kbytes": 65536, // cap the send queue at 64 MiB (default 1 GiB)
+    "queue.buffering.max.messages": 100000,
+    "batch.size": 1000000, // keep batches large for throughput
+  },
+});
+```
+
+**Protected keys.** To avoid weakening the connection, `producerConfig` cannot set or override:
+
+- security/connection keys — `bootstrap.servers`, `security.protocol`, `ssl.*`, `sasl.*`, and `enable.ssl.certificate.verification` (configure these via `brokers`, `sasl`, and `tls` instead);
+- any property already managed by the typed fields above (e.g. `acks`, `compression.type`, `linger.ms`, `batch.num.messages`).
+
+Such keys are ignored with a warning in the logs rather than overriding the managed value.
 
 ### Manage multiple writers for various topics
 

--- a/docs/writers.md
+++ b/docs/writers.md
@@ -52,7 +52,7 @@ All the parameters are named following the camelCase notation style.
 
 ### Tuning the underlying client with `producerConfig`
 
-The writer is backed by [librdkafka](https://github.com/confluentinc/librdkafka) (via `confluent-kafka-go`). The typed fields above only map a handful of properties; `producerConfig` is an escape hatch that passes any [librdkafka producer property](https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md) straight to the client.
+The writer is backed by [librdkafka](https://github.com/confluentinc/librdkafka) (via `confluent-kafka-go`). The typed fields above only map a handful of properties; `producerConfig` is an escape hatch that passes any [librdkafka producer property](https://docs.confluent.io/platform/current/clients/librdkafka/html/md_CONFIGURATION.html) straight to the client. See that page for the full list of available settings.
 
 This is the main lever for **bounding per-client memory**. Each writer is its own librdkafka instance, and the default send-queue ceiling (`queue.buffering.max.kbytes`) is **1 GiB per client** — so many VUs can reserve a lot of headroom. Lower it to cap memory:
 

--- a/pkg/kafka/confluent_config.go
+++ b/pkg/kafka/confluent_config.go
@@ -2,13 +2,105 @@ package kafka
 
 import (
 	"context"
+	"fmt"
 	"maps"
+	"math"
 	"strconv"
 	"strings"
 	"time"
 
 	ckafka "github.com/confluentinc/confluent-kafka-go/v2/kafka"
 )
+
+// reservedSecurityConfigPrefixes lists connection- and security-critical
+// librdkafka properties that the typed configuration owns exclusively. Raw
+// passthrough config must never set or override these — even when the typed
+// config leaves them unset — so a stray override cannot weaken TLS/SASL,
+// re-enable an insecure transport, or redirect the broker list.
+var reservedSecurityConfigPrefixes = []string{
+	"bootstrap.servers",
+	"security.protocol",
+	"ssl.",
+	"sasl.",
+	"enable.ssl.certificate.verification",
+}
+
+func isReservedSecurityConfigKey(key string) bool {
+	for _, prefix := range reservedSecurityConfigPrefixes {
+		if key == prefix || strings.HasPrefix(key, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// normalizeConfluentConfigValue coerces a value coming from JS/JSON into a type
+// that confluent-kafka-go's value2string understands (bool, int, string). JSON
+// decoding yields float64 for every number and sobek may yield int64, neither
+// of which librdkafka accepts directly.
+func normalizeConfluentConfigValue(value any) (any, error) {
+	switch v := value.(type) {
+	case bool, string, int:
+		return v, nil
+	case int64:
+		return int(v), nil
+	case int32:
+		return int(v), nil
+	case float64:
+		if v == math.Trunc(v) {
+			return int(v), nil
+		}
+		return nil, fmt.Errorf("%w: got non-integer number %v", errInvalidRawConfigValue, v)
+	case float32:
+		f := float64(v)
+		if f == math.Trunc(f) {
+			return int(f), nil
+		}
+		return nil, fmt.Errorf("%w: got non-integer number %v", errInvalidRawConfigValue, v)
+	default:
+		return nil, fmt.Errorf("%w: got %T", errInvalidRawConfigValue, value)
+	}
+}
+
+// applyRawConfigOverrides merges user-supplied librdkafka properties into config.
+// It is deliberately conservative:
+//   - security/connection keys (reservedSecurityConfigPrefixes) are rejected, so
+//     TLS, SASL, and the broker list cannot be tampered with.
+//   - keys already set by the typed configuration are preserved, so existing
+//     ("legacy") settings are never clobbered.
+//
+// Both categories are skipped with a warning rather than failing the run; only a
+// malformed value (e.g. a non-integer number) aborts, since that signals a real
+// mistake in the supplied config.
+func applyRawConfigOverrides(config ckafka.ConfigMap, raw map[string]any) error {
+	for key, rawValue := range raw {
+		if isReservedSecurityConfigKey(key) {
+			logger.Warnf(
+				"Ignoring raw config key %q: security and connection settings cannot be overridden.",
+				key,
+			)
+			continue
+		}
+		if _, exists := config[key]; exists {
+			logger.Warnf(
+				"Ignoring raw config key %q: it is already managed by xk6-kafka and will not be overwritten.",
+				key,
+			)
+			continue
+		}
+
+		value, err := normalizeConfluentConfigValue(rawValue)
+		if err != nil {
+			return newInvalidConfigError(fmt.Sprintf("raw config key %q", key), err)
+		}
+
+		if err := setConfluentConfigValue(config, key, value); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
 
 const defaultConfluentTimeout = 5 * time.Second
 
@@ -233,6 +325,10 @@ func writerConfigToConfluentConfigMap(writerConfig *WriterConfig) (ckafka.Config
 		return nil, err
 	}
 
+	if err := applyRawConfigOverrides(config, writerConfig.ProducerConfig); err != nil {
+		return nil, err
+	}
+
 	return config, nil
 }
 
@@ -322,6 +418,10 @@ func readerConfigToConfluentConfigMap(readerConfig *ReaderConfig) (ckafka.Config
 		}
 	}
 
+	if err := applyRawConfigOverrides(config, readerConfig.ConsumerConfig); err != nil {
+		return nil, err
+	}
+
 	return config, nil
 }
 
@@ -346,6 +446,10 @@ func connectionConfigToConfluentConfigMap(connectionConfig *ConnectionConfig) (c
 	}
 
 	if err := applyConfluentSecurityConfig(config, connectionConfig.SASL, connectionConfig.TLS); err != nil {
+		return nil, err
+	}
+
+	if err := applyRawConfigOverrides(config, connectionConfig.ClientConfig); err != nil {
 		return nil, err
 	}
 

--- a/pkg/kafka/confluent_config_test.go
+++ b/pkg/kafka/confluent_config_test.go
@@ -352,6 +352,115 @@ func TestConnectionConfigToConfluentConfigMap_Table(t *testing.T) {
 	})
 }
 
+func TestNormalizeConfluentConfigValue(t *testing.T) {
+	t.Parallel()
+	t.Run("integral float64 becomes int", func(t *testing.T) {
+		t.Parallel()
+		v, err := normalizeConfluentConfigValue(float64(16384))
+		require.NoError(t, err)
+		assert.Equal(t, 16384, v)
+	})
+	t.Run("int64 becomes int", func(t *testing.T) {
+		t.Parallel()
+		v, err := normalizeConfluentConfigValue(int64(100000))
+		require.NoError(t, err)
+		assert.Equal(t, 100000, v)
+	})
+	t.Run("string and bool pass through", func(t *testing.T) {
+		t.Parallel()
+		s, err := normalizeConfluentConfigValue("lz4")
+		require.NoError(t, err)
+		assert.Equal(t, "lz4", s)
+		b, err := normalizeConfluentConfigValue(true)
+		require.NoError(t, err)
+		assert.Equal(t, true, b)
+	})
+	t.Run("non-integer number is rejected", func(t *testing.T) {
+		t.Parallel()
+		_, err := normalizeConfluentConfigValue(float64(1.5))
+		require.ErrorIs(t, err, errInvalidRawConfigValue)
+	})
+	t.Run("unsupported type is rejected", func(t *testing.T) {
+		t.Parallel()
+		_, err := normalizeConfluentConfigValue([]string{"x"})
+		require.ErrorIs(t, err, errInvalidRawConfigValue)
+	})
+}
+
+func TestApplyRawConfigOverrides(t *testing.T) {
+	t.Parallel()
+	t.Run("applies new key with float normalization", func(t *testing.T) {
+		t.Parallel()
+		cfg := ckafka.ConfigMap{}
+		err := applyRawConfigOverrides(cfg, map[string]any{
+			"queue.buffering.max.kbytes": float64(65536),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 65536, cfg["queue.buffering.max.kbytes"])
+	})
+	t.Run("does not overwrite an already-managed key", func(t *testing.T) {
+		t.Parallel()
+		cfg := ckafka.ConfigMap{"acks": "1"}
+		err := applyRawConfigOverrides(cfg, map[string]any{"acks": "0"})
+		require.NoError(t, err)
+		assert.Equal(t, "1", cfg["acks"])
+	})
+	t.Run("rejects security and connection keys", func(t *testing.T) {
+		t.Parallel()
+		cfg := ckafka.ConfigMap{}
+		err := applyRawConfigOverrides(cfg, map[string]any{
+			"security.protocol":                   "PLAINTEXT",
+			"ssl.ca.location":                     "/tmp/evil.pem",
+			"sasl.password":                       "hunter2",
+			"enable.ssl.certificate.verification": false,
+			"bootstrap.servers":                   "evil:9092",
+		})
+		require.NoError(t, err)
+		assert.Empty(t, cfg)
+	})
+	t.Run("malformed value aborts", func(t *testing.T) {
+		t.Parallel()
+		cfg := ckafka.ConfigMap{}
+		err := applyRawConfigOverrides(cfg, map[string]any{"linger.ms": 1.5})
+		require.Error(t, err)
+	})
+	t.Run("nil map is a no-op", func(t *testing.T) {
+		t.Parallel()
+		cfg := ckafka.ConfigMap{}
+		require.NoError(t, applyRawConfigOverrides(cfg, nil))
+	})
+}
+
+func TestRawConfigPassthroughEndToEnd(t *testing.T) {
+	t.Parallel()
+	t.Run("producer config applies and protects managed keys", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := writerConfigToConfluentConfigMap(&WriterConfig{
+			Brokers:      []string{"localhost:9092"},
+			RequiredAcks: 1,
+			ProducerConfig: map[string]any{
+				"queue.buffering.max.kbytes": float64(65536),
+				"acks":                       "0",          // managed → must be ignored
+				"security.protocol":          "PLAINTEXT", // security → must be ignored
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 65536, cfg["queue.buffering.max.kbytes"])
+		assert.Equal(t, "1", cfg["acks"])
+	})
+	t.Run("consumer config applies", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := readerConfigToConfluentConfigMap(&ReaderConfig{
+			Brokers: []string{"localhost:9092"},
+			ConsumerConfig: map[string]any{
+				"queued.max.messages.kbytes": float64(4096),
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 4096, cfg["queued.max.messages.kbytes"])
+	})
+}
+
 func TestConfluentOffset(t *testing.T) {
 	t.Parallel()
 	t.Run("explicit offset wins", func(t *testing.T) {

--- a/pkg/kafka/confluent_config_test.go
+++ b/pkg/kafka/confluent_config_test.go
@@ -440,7 +440,7 @@ func TestRawConfigPassthroughEndToEnd(t *testing.T) {
 			RequiredAcks: 1,
 			ProducerConfig: map[string]any{
 				"queue.buffering.max.kbytes": float64(65536),
-				"acks":                       "0",          // managed → must be ignored
+				"acks":                       "0",         // managed → must be ignored
 				"security.protocol":          "PLAINTEXT", // security → must be ignored
 			},
 		})

--- a/pkg/kafka/reader.go
+++ b/pkg/kafka/reader.go
@@ -67,6 +67,11 @@ type ReaderConfig struct {
 	OffsetOutOfRangeError  bool          `json:"offsetOutOfRangeError"` // deprecated, do not use
 	SASL                   SASLConfig    `json:"sasl"`
 	TLS                    TLSConfig     `json:"tls"`
+	// ConsumerConfig passes raw librdkafka consumer properties straight to the
+	// underlying client (e.g. "queued.max.messages.kbytes"). Security and
+	// connection keys, and any property already managed by the fields above,
+	// are ignored and cannot be overridden.
+	ConsumerConfig map[string]any `json:"consumerConfig"`
 }
 
 type ConsumeConfig struct {

--- a/pkg/kafka/reader.go
+++ b/pkg/kafka/reader.go
@@ -71,6 +71,9 @@ type ReaderConfig struct {
 	// underlying client (e.g. "queued.max.messages.kbytes"). Security and
 	// connection keys, and any property already managed by the fields above,
 	// are ignored and cannot be overridden.
+	//
+	// Full list of properties:
+	// https://docs.confluent.io/platform/current/clients/librdkafka/html/md_CONFIGURATION.html
 	ConsumerConfig map[string]any `json:"consumerConfig"`
 }
 

--- a/pkg/kafka/static_errors.go
+++ b/pkg/kafka/static_errors.go
@@ -8,6 +8,7 @@ var (
 	errEmptyTopicResultSet                   = errors.New("empty topic result set")
 	errExpectedObject                        = errors.New("expected object")
 	errGroupTopicsMustNotBeEmpty             = errors.New("groupTopics must not be empty")
+	errInvalidRawConfigValue                 = errors.New("raw config value must be a string, bool, or integer")
 	errNoPositionsReturned                   = errors.New("no positions returned")
 	errObjectMustNotBeNil                    = errors.New("object must not be nil")
 	errPartitionOutOfRange                   = errors.New("partition is out of int32 range")

--- a/pkg/kafka/topic.go
+++ b/pkg/kafka/topic.go
@@ -12,6 +12,10 @@ type ConnectionConfig struct {
 	Brokers []string   `json:"brokers"`
 	SASL    SASLConfig `json:"sasl"`
 	TLS     TLSConfig  `json:"tls"`
+	// ClientConfig passes raw librdkafka properties straight to the underlying
+	// admin/producer client. Security and connection keys, and any property
+	// already managed by the fields above, are ignored and cannot be overridden.
+	ClientConfig map[string]any `json:"clientConfig"`
 }
 
 func (k *Kafka) adminClientClass(call sobek.ConstructorCall) *sobek.Object {

--- a/pkg/kafka/topic.go
+++ b/pkg/kafka/topic.go
@@ -15,6 +15,9 @@ type ConnectionConfig struct {
 	// ClientConfig passes raw librdkafka properties straight to the underlying
 	// admin/producer client. Security and connection keys, and any property
 	// already managed by the fields above, are ignored and cannot be overridden.
+	//
+	// Full list of properties:
+	// https://docs.confluent.io/platform/current/clients/librdkafka/html/md_CONFIGURATION.html
 	ClientConfig map[string]any `json:"clientConfig"`
 }
 

--- a/pkg/kafka/writer.go
+++ b/pkg/kafka/writer.go
@@ -53,6 +53,11 @@ type WriterConfig struct {
 	WriteTimeout    time.Duration   `mapstructure:"writeTimeout"`
 	SASL            SASLConfig      `mapstructure:"sasl"`
 	TLS             TLSConfig       `mapstructure:"tls"`
+	// ProducerConfig passes raw librdkafka producer properties straight to the
+	// underlying client (e.g. "queue.buffering.max.kbytes"). Security and
+	// connection keys, and any property already managed by the fields above,
+	// are ignored and cannot be overridden.
+	ProducerConfig map[string]any `mapstructure:"producerConfig"`
 }
 
 func (c *WriterConfig) Parse(m map[string]any, runtime *sobek.Runtime) error {

--- a/pkg/kafka/writer.go
+++ b/pkg/kafka/writer.go
@@ -57,6 +57,9 @@ type WriterConfig struct {
 	// underlying client (e.g. "queue.buffering.max.kbytes"). Security and
 	// connection keys, and any property already managed by the fields above,
 	// are ignored and cannot be overridden.
+	//
+	// Full list of properties:
+	// https://docs.confluent.io/platform/current/clients/librdkafka/html/md_CONFIGURATION.html
 	ProducerConfig map[string]any `mapstructure:"producerConfig"`
 }
 


### PR DESCRIPTION
## What

Adds an escape-hatch config map to each client so k6 scripts can pass arbitrary [librdkafka properties](https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md) straight through to the underlying `confluent-kafka-go` client:

| Client | New field |
|---|---|
| `Writer` / Producer | `producerConfig` |
| `Reader` / Consumer | `consumerConfig` |
| `Connection` / `AdminClient` | `clientConfig` |

## Why

The typed config structs only map a handful of librdkafka properties, so memory- and throughput-critical knobs were unreachable from scripts. Two motivating cases:

- **Bounding per-client memory.** Each VU spins up its own librdkafka client, and the default producer send-queue ceiling (`queue.buffering.max.kbytes`) is **1 GiB per client** — with many VUs that reserves a lot of headroom. The passthrough lets scripts cap `queue.buffering.max.kbytes` / `queued.max.messages.kbytes`.
- **Batch sizing.** `batch.size` is bounded by `message.max.bytes` (default 1 MB), so large messages batch poorly until `message.max.bytes` is raised — another property that was previously unreachable.

## Safety

The merge is intentionally conservative:

- **Security/connection keys cannot be overridden** — `bootstrap.servers`, `security.protocol`, `ssl.*`, `sasl.*`, `enable.ssl.certificate.verification` (configure via `brokers`/`sasl`/`tls` instead).
- **Keys already set by the typed config are preserved** (e.g. `acks`, `compression.type`, `linger.ms`, `batch.num.messages`).
- Both are skipped with a warning; only a malformed value aborts the run.
- Numeric values from JS/JSON (`float64`/`int64`) are normalized to `int` so librdkafka's `value2string` accepts them.

## Tests

Unit tests cover value normalization, both protection layers, malformed-value abort, and end-to-end through the writer/reader builders. `go build` and `go vet` are clean.

Also verified end-to-end against a live broker (`lensesio/fast-data-dev`) with a binary built from this branch:

- The passthrough reaches librdkafka: changing `queue.buffering.max.kbytes` changes the observed queue depth (1 MB cap → ~6 messages held; 200 MB → all 49).
- Protected-key warnings fire as designed for `acks` and `security.protocol`.
- `debug` passes through (librdkafka debug output appears on stderr).

## Docs

- `docs/writers.md` / `docs/readers.md`: document the new fields plus a tuning section with the memory-cap example and protected-keys list.